### PR TITLE
Performance fix: avoid redundant analyses.

### DIFF
--- a/gedit_flake8/__init__.py
+++ b/gedit_flake8/__init__.py
@@ -248,17 +248,13 @@ class Flake8Plugin(GObject.Object, Gedit.WindowActivatable):
         bottom_panel = self.window.get_bottom_panel()
         bottom_panel.remove_item(self._panel)
 
-    def do_update_state(self):
-        """Parse the document when loaded"""
-        document = self.window.get_active_document()
-        self.analyse(document, None)
-
     def on_tab_added(self, window, tab):
         """Initialize the required vars"""
         document = tab.get_document()
 
         self._results[document] = ResultsModel()
         self._errors[document] = []
+        document.connect('loaded', self.analyse)
         document.connect('saved', self.analyse)
         document.connect('cursor-moved', self.display_error_msg)
         self._add_tags(document)


### PR DESCRIPTION
Flake8 is relatively fast, but do_update_state is called many time
at each load and save, making the whole thing slow.
(1 second to save on a SSD-powered laptop?!)

According to the docstring, the method is only there to start one analysis
on load. The 'loaded' signal does a better job at this (it is only triggered
once per call) and works the same as 'saved'.

Loading and saving (on my machine) is still noticably slower than without
the plugin, but it is now much better than before.
